### PR TITLE
plugins no longer have a "test" property or constructor option called "debug" as of magellan 7

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -2,9 +2,12 @@ var fs = require("fs");
 
 var settings = {
   nightwatchConfigFilePath: undefined,
+  debug: false,
 
   initialize: function (argv) {
-    settings.nightwatchConfigFilePath = 
+    settings.debug = argv.debug;
+
+    settings.nightwatchConfigFilePath =
       argv.nightwatch_config
       || (fs.existsSync("./nightwatch.json") ? "./nightwatch.json" : "./conf/nightwatch.json");
   }

--- a/lib/test_run.js
+++ b/lib/test_run.js
@@ -57,7 +57,7 @@ NightwatchTestrun.prototype.getArguments = function () {
     "--mocking_port=" + this.mockingPort,
     // Nightwatch gets its sauce browser setting via a nightwatch configuration file
     // If we're not in sauce mode, we just pass in a browserId directly (i.e. phantomjs, chrome, firefox, etc)
-    "--env=" + (this.sauceBrowserSettings ? "sauce" : this.test.browser.browserId),
+    "--env=" + (this.sauceBrowserSettings ? "sauce" : this.environmentId),
     "--test=" + this.locator.filename,
     // NOTE: the --worker=1 argument tells magellan-nightwatch that it's in
     // "worker mode" and should send IPC messages back to magellan.
@@ -69,7 +69,7 @@ NightwatchTestrun.prototype.getArguments = function () {
     args.push("--screenshot_path=" + this.tempAssetPath);
   }
 
-  if (this.debug) {
+  if (settings.debug) {
     args.push("--verbose");
   }
 


### PR DESCRIPTION
Prepare plugin for new API
