### PR TITLE
allow sauce tunnel id

### DIFF
--- a/lib/rewrite_config.js
+++ b/lib/rewrite_config.js
@@ -76,6 +76,10 @@ module.exports = function (sourceConfigPath, tempAssetPath, options) {
 
     if (options.sauceSettings.tunnelId) {
       conf.test_settings.sauce.desiredCapabilities["tunnel-identifier"] = options.sauceSettings.tunnelId;
+      if (options.sauceSettings.sharedSauceParentAccount) {
+        // if tunnel is shared by parent account
+        conf.test_settings.sauce.desiredCapabilities["parent-tunnel"] = options.sauceSettings.sharedSauceParentAccount;
+      }
     } else {
       // This property may exist, so blow it away
       delete conf.test_settings.sauce.desiredCapabilities["tunnel-identifier"];

--- a/lib/test_run.js
+++ b/lib/test_run.js
@@ -24,7 +24,7 @@ NightwatchTestrun.prototype._createTemporaryConfigFile = function () {
   if (this.sauceBrowserSettings) {
     sauceSettings = _.extend({}, this.sauceSettings);
 
-    if (this.sauceSettings.useTunnels) {
+    if (this.sauceSettings.useTunnels || this.sauceSettings.sauceTunnelId) {
       // The sauce worker allocator has a specific tunnelId for this sauce run,
       // we have to use it to avoid using the tunnels of adjacent workers.
       sauceSettings.tunnelId = this.tunnelId;


### PR DESCRIPTION
allow setting `--tunnel_identifier` in browser capabilities if magellan provides a sauce_tunnel_id directly.

@Maciek416 @geekdave 
