### PR TITLE
allow @tags

### DIFF
--- a/lib/tag_filter.js
+++ b/lib/tag_filter.js
@@ -36,7 +36,9 @@ var isMatched = function (tags, f) {
     if (!foundTags && !pass) {
       if (nodeType === "Property"
         && node.key
-        && (node.key.name === "tags" || node.key.value === "@tags")
+        && (node.key.name === "tags"        // for tags: []
+          || node.key.value === "@tags"     // for "@tags": []
+          || node.key.value === "tags")     // for "tags": []
         && node.value
         && node.value.type === "ArrayExpression"
         && node.value.elements) {

--- a/lib/tag_filter.js
+++ b/lib/tag_filter.js
@@ -34,7 +34,12 @@ var isMatched = function (tags, f) {
     // Don't continue scanning if we've already passed or if we've already
     // found the tags: [] structure.
     if (!foundTags && !pass) {
-      if (nodeType === "Property" && node.key && node.key.name === "tags" && node.value && node.value.type === "ArrayExpression" && node.value.elements) {
+      if (nodeType === "Property"
+        && node.key
+        && (node.key.name === "tags" || node.key.value === "@tags")
+        && node.value
+        && node.value.type === "ArrayExpression"
+        && node.value.elements) {
         foundTags = true;
 
         // Collect the tags this test matches

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testarmada-magellan-nightwatch-plugin",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "Magellan plugin to provide Nightwatch.js support",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR allows user to set nightwatch tags as `"@tags"` as well as `tags` and `"tags"` in the test, all are supported by nightwatchjs.