### PR TITLE
Add support for nightwatch config via .js files

### DIFF
--- a/lib/rewrite_config.js
+++ b/lib/rewrite_config.js
@@ -9,7 +9,7 @@ var CHROMEDRIVER_LOCATION = "./node_modules/chromedriver/lib/chromedriver/chrome
 var PHANTOMJS_LOCATION = "./node_modules/phantomjs/bin/phantomjs";
 // throws file read/write exceptions, JSON parse exceptions
 module.exports = function (sourceConfigPath, tempAssetPath, options) {
-  var conf = JSON.parse(fs.readFileSync(path.resolve(sourceConfigPath), "utf8"));
+  var conf = require(path.resolve(sourceConfigPath));
 
   if (options.syncBrowsers) {
     if (!conf.test_settings.default.globals) {


### PR DESCRIPTION
Switches config loading to allow minimal support for Nightwatch config via JS files (not just JSON).

This should work for any configuration that works with Nightwatch (provided it exports a config object). 

`rewrite_config.js` still exports temporary configuration files as JSON.
