### PR TITLE
Avoid mutating source config during rewrite

### DIFF
--- a/lib/rewrite_config.js
+++ b/lib/rewrite_config.js
@@ -61,12 +61,11 @@ module.exports = function (sourceConfigPath, tempAssetPath, options) {
     }
   }
   
-  var test_settings = _.cloneDeep(conf.test_settings[options.executor]);
-  conf.test_settings[options.executor]
-    = _.merge(test_settings, options.executorCapabilities);
+  var confClone = _.cloneDeep(conf);
+  _.merge(confClone.test_settings[options.executor], options.executorCapabilities);
   // Write all the above details to a temporary config file, then return the temporary filename
   var tempConfigPath = path.resolve(tempAssetPath + '/' + newSourceConfigPath);
-  fs.writeFileSync(tempConfigPath, JSON.stringify(conf), "utf8");
+  fs.writeFileSync(tempConfigPath, JSON.stringify(confClone), "utf8");
 
   if (path.extname(tempConfigPath) === '.js') {
     try {


### PR DESCRIPTION
Fixes a bug that was causing generated nightwatch config to contain incorrect (and incompatible) desiredCapabilities when running Magellan against multiple browsers.