### PR TITLE
Check for dependencies existence

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -9,12 +9,8 @@ module.exports = function (options) {
     rootWorkingDirectory: process.cwd()
   }
   */
-  var rootPkgDeps = options.rootPackage.dependencies;
-  
-  if (!rootPkgDeps) {
-    rootPkgDeps = {};
-  }
-  
+  var rootPkgDeps = options.rootPackage.dependencies || {};
+    
   // get exact selenium-server version
   var seleniumServerVersion;
   if (rootPkgDeps["selenium-server"]) {

--- a/lib/options.js
+++ b/lib/options.js
@@ -9,15 +9,21 @@ module.exports = function (options) {
     rootWorkingDirectory: process.cwd()
   }
   */
+  var rootPkgDeps = options.rootPackage.dependencies;
+  
+  if (!rootPkgDeps) {
+    rootPkgDeps = {};
+  }
+  
   // get exact selenium-server version
   var seleniumServerVersion;
-  if (options.rootPackage.dependencies["selenium-server"]) {
+  if (rootPkgDeps["selenium-server"]) {
     seleniumServerVersion = require(path.join(options.rootWorkingDirectory, "/node_modules/selenium-server/package.json")).version;
   }
 
   return {
     seleniumServerVersion : seleniumServerVersion,
-    isChromedriverPresent: options.rootPackage.dependencies["chromedriver"] !== undefined,
-    isPhantomjsPresent: options.rootPackage.dependencies["phantomjs"] !== undefined
+    isChromedriverPresent: rootPkgDeps["chromedriver"] !== undefined,
+    isPhantomjsPresent: rootPkgDeps["phantomjs"] !== undefined
   };
 };


### PR DESCRIPTION
If there is no `dependencies` in the project `package.json` this will currently error out, so this protects against that.