### PR TITLE
Add check_subfolders and ignore_folders options

### DIFF
--- a/lib/get_tests.js
+++ b/lib/get_tests.js
@@ -13,6 +13,12 @@ var filterFiles = function (files) {
   });
 };
 
+var filterFolders = function (folders) {
+  return folders.filter(function (f) {
+    return (f);
+  });
+};
+
 module.exports = function () {
   var nightwatchConfigFilePath = settings.nightwatchConfigFilePath;
   var nightwatchConfig;
@@ -33,6 +39,30 @@ module.exports = function () {
   }
 
   var srcFolders = nightwatchConfig.src_folders;
+
+  if (srcFolders.length > 0 && nightwatchConfig.check_subfolders) {
+    var allFolders = [];
+    srcFolders.forEach(function (folder) {
+      var p = path.normalize(folder);
+      var folders = fs.readdirSync(p);
+
+      if (folders.length > 0) {
+        var additionalFolders = filterFolders(folders.map(function (f) {
+          if (f.indexOf(".") === -1) {
+            if (nightwatchConfig.ignore_folders) {
+              if (!nightwatchConfig.ignore_folders.includes(f)) {
+                return path.normalize(folder) + "/" + f;
+              }
+            } else {
+              return path.normalize(folder) + "/" + f;
+            }
+          }
+        }));
+        allFolders = allFolders.concat(additionalFolders);
+      }
+    });
+    srcFolders = allFolders;
+  }
 
   var allFiles = [];
   srcFolders.forEach(function (folder) {


### PR DESCRIPTION
* Add **check_subfolders** and **ignore_folders** options in get_tests.js. Both options are optional and specified through the nightwatch.json config.
